### PR TITLE
make it work with latest stable-fast

### DIFF
--- a/module/stable_diffusion_pipeline_compiler.py
+++ b/module/stable_diffusion_pipeline_compiler.py
@@ -28,9 +28,6 @@ class CompilationConfig:
 
 
 def compile_unet(unet_funtion, config, device):
-    if config.memory_format is not None:
-        unet_funtion.to(memory_format=config.memory_format)
-
     enable_cuda_graph = config.enable_cuda_graph and device.type == 'cuda'
 
     with torch.no_grad():

--- a/module/stable_diffusion_pipeline_compiler.py
+++ b/module/stable_diffusion_pipeline_compiler.py
@@ -27,13 +27,11 @@ class CompilationConfig:
         enable_triton: bool = False
 
 
-def compile_unet(unet_funtion, config, device, XL=False):
-    enable_cuda_graph = config.enable_cuda_graph and device.type == 'cuda'
+def compile_unet(unet_funtion, config, device):
+    if config.memory_format is not None:
+        unet_funtion.to(memory_format=config.memory_format)
 
-    if XL:
-        if enable_cuda_graph:
-            logger.warning('CUDA Graph with SDXL is observed to be slow, it will be disabled')
-            enable_cuda_graph = False
+    enable_cuda_graph = config.enable_cuda_graph and device.type == 'cuda'
 
     with torch.no_grad():
         if config.enable_xformers:
@@ -52,11 +50,14 @@ def compile_unet(unet_funtion, config, device, XL=False):
                 memory_format=config.memory_format,
             )
 
-            def ts_compiler(m,
-                            call_helper,
-                            inputs,
-                            kwarg_inputs,
-                            freeze=False):
+            def ts_compiler(
+                m,
+                call_helper,
+                inputs,
+                kwarg_inputs,
+                freeze=False,
+                enable_cuda_graph=False,
+            ):
                 with torch.jit.optimized_execution(True):
                     if freeze:
                         # raw freeze causes Tensor reference leak
@@ -65,18 +66,19 @@ def compile_unet(unet_funtion, config, device, XL=False):
                         m.eval()
                         m = jit_utils.better_freeze(m)
                     modify_model(m)
+
+                if enable_cuda_graph:
+                    m = make_dynamic_graphed_callable(m)
                 return m
 
             unet_forward = lazy_trace(to_module(unet_funtion),
                                       ts_compiler=functools.partial(
                                           ts_compiler,
                                           freeze=config.enable_jit_freeze,
-            ),
-                check_trace=False,
-                strict=False)
-
-            if enable_cuda_graph:
-                unet_forward = make_dynamic_graphed_callable(unet_forward)
+                                          enable_cuda_graph=enable_cuda_graph,
+                                      ),
+                                      check_trace=False,
+                                      strict=False)
 
             @functools.wraps(unet_funtion)
             def unet_forward_wrapper(sample, t, *args, **kwargs):
@@ -88,133 +90,6 @@ def compile_unet(unet_funtion, config, device, XL=False):
         return unet_funtion
 
 
-def compile(m, config):
-    enable_cuda_graph = config.enable_cuda_graph and m.device.type == 'cuda'
-
-    if 'XL' in m.__class__.__name__:
-        if enable_cuda_graph:
-            logger.warning('CUDA Graph with SDXL is observed to be slow, it will be disabled')
-            enable_cuda_graph = False
-
-    with torch.no_grad():
-
-        if config.enable_xformers:
-            if config.enable_jit:
-                from sfast.utils.xformers_attention import xformers_memory_efficient_attention
-                from xformers import ops
-
-                ops.memory_efficient_attention = xformers_memory_efficient_attention
-
-            m.enable_xformers_memory_efficient_attention()
-        '''
-        if config.enable_triton:
-            import sfast.triton.modules.patch as tm_patch
-            modules_to_patch = [
-                m.unet,
-                m.vae,
-                m.text_encoder,
-            ]
-            if hasattr(m, 'controlnet'):
-                modules_to_patch.append(m.controlnet)
-            for module in modules_to_patch:
-                tm_patch.patch_lora_compatible_conv(module)
-                tm_patch.patch_lora_compatible_linear(module)
-                # tm_patch.patch_conv2d(module)
-                # tm_patch.patch_linear(module)
-                # tm_patch.patch_group_norm_silu(module)
-                # tm_patch.patch_group_norm(module)
-        '''
-
-        if config.memory_format == torch.channels_last:
-            m.unet.to(memory_format=torch.channels_last)
-            m.vae.to(memory_format=torch.channels_last)
-            if hasattr(m, 'controlnet'):
-                m.controlnet.to(memory_format=torch.channels_last)
-
-        if config.enable_jit:
-            modify_model = functools.partial(
-                _modify_model,
-                enable_cnn_optimization=config.enable_cnn_optimization,
-                prefer_lowp_gemm=config.prefer_lowp_gemm,
-                enable_triton=config.enable_triton,
-                memory_format=config.memory_format,
-            )
-
-            def ts_compiler(m,
-                            call_helper,
-                            inputs,
-                            kwarg_inputs,
-                            freeze=False):
-                with torch.jit.optimized_execution(True):
-                    if freeze:
-                        # raw freeze causes Tensor reference leak
-                        # because the constant Tensors in the GraphFunction of
-                        # the compilation unit are never freed.
-                        m = jit_utils.better_freeze(m)
-                    modify_model(m)
-                return m
-
-            lazy_trace_ = functools.partial(
-                lazy_trace,
-                ts_compiler=functools.partial(
-                    ts_compiler,
-                    freeze=config.enable_jit_freeze,
-                ),
-                check_trace=False,
-                strict=False)
-
-            # disable jit for text_encoder because of exception caused by
-            # tracing BaseModelOutputPooling of StableDiffusionXLPipeline
-            # m.text_encoder.forward = lazy_trace_(
-            #     to_module(m.text_encoder.forward))
-            unet_forward = lazy_trace(to_module(m.unet.forward),
-                                      ts_compiler=functools.partial(
-                                          ts_compiler,
-                                          freeze=config.enable_jit_freeze,
-            ),
-                check_trace=False,
-                strict=False)
-
-            if enable_cuda_graph:
-                unet_forward = make_dynamic_graphed_callable(unet_forward)
-
-            @functools.wraps(m.unet.forward)
-            def unet_forward_wrapper(sample, t, *args, **kwargs):
-                t = t.to(device=sample.device)
-                return unet_forward(sample, t, *args, **kwargs)
-
-            m.unet.forward = unet_forward_wrapper
-
-            if packaging.version.parse(
-                    torch.__version__) < packaging.version.parse('2.0.0'):
-                m.vae.decode = lazy_trace_(to_module(m.vae.decode))
-                # For img2img
-                m.vae.encoder.forward = lazy_trace_(
-                    to_module(m.vae.encoder.forward))
-                m.vae.quant_conv.forward = lazy_trace_(
-                    to_module(m.vae.quant_conv.forward))
-
-            if hasattr(m, 'controlnet'):
-                controlnet_forward = lazy_trace(
-                    to_module(m.controlnet.forward),
-                    ts_compiler=functools.partial(ts_compiler, freeze=False),
-                    check_trace=False,
-                    strict=False)
-
-                @functools.wraps(m.controlnet.forward)
-                def controlnet_forward_wrapper(sample, t, *args, **kwargs):
-                    t = t.to(device=sample.device)
-                    return controlnet_forward(sample, t, *args, **kwargs)
-
-                m.controlnet.forward = controlnet_forward_wrapper
-
-                if enable_cuda_graph and m.device.type == 'cuda':
-                    m.controlnet.forward = make_dynamic_graphed_callable(
-                        m.controlnet.forward, )
-
-        return m
-
-
 def _modify_model(m,
                   enable_cnn_optimization=True,
                   prefer_lowp_gemm=True,
@@ -224,6 +99,7 @@ def _modify_model(m,
         from sfast.jit.passes import triton_passes
 
     torch._C._jit_pass_inline(m.graph)
+    passes.jit_pass_remove_dropout(m.graph)
 
     passes.jit_pass_remove_contiguous(m.graph)
     passes.jit_pass_replace_view_with_reshape(m.graph)

--- a/node.py
+++ b/node.py
@@ -32,6 +32,10 @@ class ApplyStableFastUnet:
 
     def apply_stable_fast(self, model):
         config = CompilationConfig.Default()
+
+        if config.memory_format is not None:
+            model.model.to(memory_format=config.memory_format)
+
         # xformers and triton are suggested for achieving best performance.
         # It might be slow for triton to generate, compile and fine-tune kernels.
         try:

--- a/node.py
+++ b/node.py
@@ -43,16 +43,16 @@ class ApplyStableFastUnet:
             config.enable_xformers = True
         except ImportError:
             print('xformers not installed, skip')
-        try:
-            import triton
-            config.enable_triton = True
-        except ImportError:
-            print('triton not installed, skip')
+        # try:
+        #     import triton
+        #     config.enable_triton = True
+        # except ImportError:
+        #     print('triton not installed, skip')
         # CUDA Graph is suggested for small batch sizes.
         # After capturing, the model only accepts one fixed image size.
         # If you want the model to be dynamic, don't enable it.
-        config.enable_cuda_graph = False
-        config.enable_jit_freeze = False
+        config.enable_cuda_graph = True
+        # config.enable_jit_freeze = False
 
         patch = StableFastPatch(model, config)
         model_stable_fast = model.clone()


### PR DESCRIPTION
I have helped to make it work with latest stable-fast.

But there seems to be a bug from Triton that makes some Triton kernel incompatible with CUDA Graph & JIT freeze in ComfyUI.

Workaround is to disable Triton or disable CUDA Graph and JIT freeze.
Now I choose to disable Triton because CUDA Graph and JIT freeze can speed up more when batch size is small.